### PR TITLE
The xmlOutput doesn't work.

### DIFF
--- a/strophe.stream-management.js
+++ b/strophe.stream-management.js
@@ -178,19 +178,15 @@ Strophe.addConnectionPlugin('streamManagement', {
 	* @method Send
 	* @public
 	*/
-	xmlOutput: function(elem) {
-		var child;
-		for (var i = 0; i < elem.children.length; i++) {
-			child = elem.children[i];
-			if (Strophe.isTagEqual(child, 'iq') ||
-			Strophe.isTagEqual(child, 'presence') ||
-			Strophe.isTagEqual(child, 'message')) {
-				this._increaseSentStanzasCounter(child);
-			}
+	 xmlOutput: function (elem) {
+		if (Strophe.isTagEqual(elem, 'iq') ||
+		    Strophe.isTagEqual(elem, 'presence') ||
+		    Strophe.isTagEqual(elem, 'message')) {
+		    this._increaseSentStanzasCounter(elem);
 		}
 
-		return this._originalXMLOutput.call(this._c, elem);
-	},
+        	return this._originalXMLOutput.call(this._c, elem);
+    	},
 
 	_incomingStanzaHandler: function(elem) {
 		if (Strophe.isTagEqual(elem, 'enabled') && elem.getAttribute('xmlns') === this._NS) {


### PR DESCRIPTION
xmlOutput function has an error. The function doesn't catch the iq, presence, message elements. It has to look at root xml tag, but the function looks to child element. 
Here is sample code block:

var stropheMsg =
        $msg({
            to: toJID,
            from: connection.jid,
            type: "chat",
            id: messageId
        }).c("body", { xmlns: Strophe.NS.CLIENT })
            .t(textIMMessage);
    connection.streamManagement.addAcknowledgedStanzaListener(function (messageId) {
        var toProcessId= messageId;
    });
    connection.send(stropheMsg);
    connection.streamManagement.requestAcknowledgement();

when after callback, you can process via toProcessId.